### PR TITLE
Updated String.length extension...

### DIFF
--- a/Source/Structures/extensions.swift
+++ b/Source/Structures/extensions.swift
@@ -15,7 +15,7 @@ extension String {
     
     ///compute the length of string
     var length: Int {
-        return Array(self).count
+        return countElements(self)
     }
     
     ///returns characters of a string up to a specified index


### PR DESCRIPTION
... with native Swift count function rather than casting to an Array to get the count.