### PR TITLE
Simplified isEmpty()

### DIFF
--- a/Source/Factories/LinkedList.swift
+++ b/Source/Factories/LinkedList.swift
@@ -42,17 +42,11 @@ public class LinkedList<T: Equatable> {
     
     
     
-    
     //empty list check
-    func isEmpty() ->Bool! {
+    func isEmpty() -> Bool! {
         
-        //check for nil conditions
-        if (self.count == 0 || head.key == nil) {
-            return true
-        }
-        else {
-            return false
-        }
+        // returns true if count is 0 or if the list's head is nil
+        return self.count == 0 || head.key == nil
         
     }
     


### PR DESCRIPTION
I simplified isEmpty() to return the result of the boolean expression```self.count == 0 || head.key == nil``` instead of evaluating the result and then returning it.