### PR TITLE
Fixed bug in Queue.deQueue() when removing last node.  Fixes crash in…

### DIFF
--- a/Source/Factories/Queue.swift
+++ b/Source/Factories/Queue.swift
@@ -99,7 +99,7 @@ public class Queue<T> {
           top = nextitem
         }
         else {
-            top = nil
+            top = QNode<T>()
         }
     
     


### PR DESCRIPTION
… subsequent call to count.

This fixes waynewbishop/SwiftStructures#47