### PR TITLE
Fixed bug in Queue.deQueue() when removing last node.  

### DIFF
--- a/Source/Factories/Queue.swift
+++ b/Source/Factories/Queue.swift
@@ -99,7 +99,7 @@ public class Queue<T> {
           top = nextitem
         }
         else {
-            top = nil
+            top = QNode<T>()
         }
     
     


### PR DESCRIPTION
Fixes crash in subsequent call to count.  See #47