### PR TITLE
Improvements on LinkedList

### DIFF
--- a/Source/Factories/LinkedList.swift
+++ b/Source/Factories/LinkedList.swift
@@ -230,6 +230,7 @@ public class LinkedList<T: Equatable> {
         //determine if the removal is at the head
         if (index == 0) {
             current = current?.next
+            current?.previous = nil
             head = current!
             return
         }

--- a/Source/Factories/LinkedList.swift
+++ b/Source/Factories/LinkedList.swift
@@ -144,14 +144,14 @@ public class LinkedList<T: Equatable> {
         
         
         //check for nil conditions
-        if ((index < 0) || (index > (self.count - 1))) {
+        if ((index < 0) || (index > self.count)) {
             print("link index does not exist..")
+            return
         }
         
-        
-        //establish the head node
-        if (head.key == nil) {
-            head.key = key
+        // do normal append
+        if (index == self.count) {
+            self.addLink(key)
             return
         }
         
@@ -206,7 +206,7 @@ public class LinkedList<T: Equatable> {
             
             
         } //end while
-        
+
     }
 
     

--- a/Source/Factories/LinkedList.swift
+++ b/Source/Factories/LinkedList.swift
@@ -243,6 +243,7 @@ public class LinkedList<T: Equatable> {
                 
                 //redirect the trailer and next pointers
                 trailer!.next = current?.next
+                current?.next?.previous = trailer
                 current = nil
                 break
                 

--- a/SwiftTests/LinkedTest.swift
+++ b/SwiftTests/LinkedTest.swift
@@ -111,6 +111,41 @@ class LinkedTest: XCTestCase {
         
     } //end function
     
+    
+    
+    
+    func testAddLinkAtIndex_Append() {
+        //create list and test pair
+        let linkedList: LinkedList<Int> = self.buildLinkedList()
+        let testPair: keyIndex = keyIndex(key: 4, index: linkedList.count)
+        
+        
+        linkedList.addLinkAtIndex(testPair.key, index: testPair.index)
+        linkedList.printAllKeys()
+        
+        
+        //retrieve the selected value
+        let current = linkedList.linkAtIndex(testPair.index) as LLNode!
+        
+        
+        if ((current == nil) || (current.key != testPair.key)) {
+            XCTFail("linked list addition at index failed..")
+        }
+        
+        
+        
+        linkedList.removeLinkAtIndex(testPair.index)
+        linkedList.printAllKeys()
+        
+        
+        
+        //retrieve new value at same position
+        let removed = linkedList.linkAtIndex(testPair.index)
+        if (removed != nil) {
+            XCTFail("linked list removal failed..")
+        }
+    }
+    
 
     
 


### PR DESCRIPTION
Set previous to nil when removing from LinkedList at head.
Set previous pointer of next to trailer when removing from LinkedList.
Letting LinkedList's addLinkAtIndex(...) do an append operation.
Added test for addLinkAtIndex(...) when appending.