### PR TITLE
Print the correct values for what is being compared in insertionSort

### DIFF
--- a/Source/Factories/Sorting.swift
+++ b/Source/Factories/Sorting.swift
@@ -162,7 +162,7 @@ public class Sorting {
             
             for var secondaryIndex = primaryIndex; secondaryIndex > -1; secondaryIndex-- {
                 
-                print("comparing \(key) and \(numberList[secondaryIndex])")
+                print("comparing \(key) and \(output[secondaryIndex])")
                 
                 if key < output[secondaryIndex] {
                     
@@ -200,7 +200,7 @@ public class Sorting {
             
             for var secondaryIndex = primaryIndex; secondaryIndex > -1; secondaryIndex-- {
                 
-                print("comparing \(key) and \(sequence[secondaryIndex])")
+                print("comparing \(key) and \(output[secondaryIndex])")
                 
                 if key < output[secondaryIndex] {
 


### PR DESCRIPTION
Values were being printed from the invariant, instead of the mutating `Array`. Would cause confusion to anyone relying on the console to help them understand `insertionSort`.