### PR TITLE
Binary Search Bug Fix and Update for Testing

### DIFF
--- a/Source/Factories/Sorting.swift
+++ b/Source/Factories/Sorting.swift
@@ -17,50 +17,47 @@ public class Sorting {
     /*
     binary search algorithm. Find the value at a specified index.
     note the use array slicing to adjust the upper and lower array bounds.
+    returns true if the key was found in the sequence.
     */
     
     
-    func binarySearch(sequence: Array<Int>, key: Int) {
+    func binarySearch(sequence: Array<Int>, key: Int)->Bool {
 
+        var result = false
         
         //establish indices - extensions
         let min = sequence.minIndex()
         let max = sequence.maxIndex()
         let mid = sequence.midIndex()
-
         
         //check bounds
         if key > sequence[max] || key < sequence[min] {
             print("search value \(key) not found..")
-            return
+            return false
         }
         
         
         //evaluate chosen number..
         let n = sequence[mid]
-    
         
         print(String(n) + "value attempted..")
         
-        
         if n > key {
             let slice: Array<Int> = Array(sequence[min...mid - 1])
-            self.binarySearch(slice, key: key)
+            result = self.binarySearch(slice, key: key)
         }
         
-        
-        if n < key {
+        else if n < key {
             let slice: Array<Int> = Array(sequence[mid + 1...max])
-            self.binarySearch(slice, key: key)
+            result = self.binarySearch(slice, key: key)
         }
-        
         
         else {
             print("search value \(key) found..")
-            return
+            result = true
         }
         
-        
+        return result
     }
     
     

--- a/SwiftTests/SortingTest.swift
+++ b/SwiftTests/SortingTest.swift
@@ -35,17 +35,41 @@ class SortingTest: XCTestCase {
 
     func testBinarySearch() {
         
-        var searchList: Array<Int> = Array<Int>()
-        
+        var searchList = Array<Int>()
+        var firstHalfOfList =  Array<Int>()
+        var secondHalfOfList =  Array<Int>()
 
-        //populate collection..
-        for number in 0...500 {
-            searchList.append(number)
+        //populate collection 0-399 and then 401-500 (missing 400 for testing the missing value condition)
+        for number in 0...399 {
+            firstHalfOfList.append(number)
+        }
+        for number in 401...500 {
+            secondHalfOfList.append(number)
         }
         
-        //perform theoretical search
-        sortTest.binarySearch(searchList, key: 235)
+        //combine the two halves into the full search list
+        searchList = firstHalfOfList + secondHalfOfList
         
+        //search for existing keys within range of the array
+        let resultListFirstHalf = firstHalfOfList.map{sortTest.binarySearch(searchList, key: $0)}
+        
+        for result in resultListFirstHalf {
+            XCTAssertTrue(result)
+        }
+        
+        //search for existing keys within range of the array
+        let resultListSecondHalf = secondHalfOfList.map{sortTest.binarySearch(searchList, key: $0)}
+        
+        for result in resultListSecondHalf {
+            XCTAssertTrue(result)
+        }
+        
+        //search for non-existent key within range of the array
+        XCTAssertFalse(sortTest.binarySearch(searchList, key: 400))
+        
+        //search for key outside the range of the array
+        XCTAssertFalse(sortTest.binarySearch(searchList, key: 600))
+
     }
     
 


### PR DESCRIPTION
#### Problem
When searching for a key within a non-complete array (e.g. [0,4,7,9,13,16,34] as opposed to [0,1,2,3,4,5,6,7]) the binarySearch() function returns an initial correct print statement followed by a false positive.
    
   Run:

`sorting.binarySearch([0,4,7,9,13,16,34], key: 8)`

  Result:
```
   search value 8 not found..
   search value 8 found..
```

#### Solution implemented this PR
- Updated binarySearch(_:) to be testable (now returns true or false depending on whether the key was found in the sequence)
- Updated the test to test all possible values of a given array