### PR TITLE
replaced if with a guard statement on binarySearch check bounds

### DIFF
--- a/Source/Factories/Sorting.swift
+++ b/Source/Factories/Sorting.swift
@@ -32,7 +32,7 @@ public class Sorting {
         
         
         //check bounds
-        if key > sequence[max] || key < sequence[min] {
+        guard key > sequence[min] || key < sequence[max] else {
             print("search value \(key) not found..")
             return false
         }


### PR DESCRIPTION
The use of a guard statement instead of if statement for checking the sequence bounds makes more sense here since we only want to execute the rest of the code if the condition is true.