### PR TITLE
Fixed crash when removing the first node from a LinkedList with a cou…

### DIFF
--- a/Source/Factories/LinkedList.swift
+++ b/Source/Factories/LinkedList.swift
@@ -218,19 +218,15 @@ public class LinkedList<T: Equatable> {
             return
         }
         
-
-        var current: LLNode<T>? =  head
-        var trailer: LLNode<T>?
-        var listIndex: Int = 0
-        
-        
         //determine if the removal is at the head
         if (index == 0) {
-            current = current?.next
-            head = current!
+            head = head.next != nil ? head.next! : LLNode<T>()
             return
         }
-        
+
+        var current: LLNode<T>? = head
+        var trailer: LLNode<T>?
+        var listIndex: Int = 0
         
         //iterate through the remaining items
         while (current != nil) {

--- a/SwiftTests/LinkedTest.swift
+++ b/SwiftTests/LinkedTest.swift
@@ -140,7 +140,57 @@ class LinkedTest: XCTestCase {
         
         
     }
+    
+    func testEmptyLinkedList() {
+        
+        let linkedList = LinkedList<Int>()
+        XCTAssert(linkedList.count == 0 , "Linked list count should have been 0, but was \(linkedList.count) instead")
+        
+        linkedList.addLink(0)
+        linkedList.removeLinkAtIndex(0)
+        
+        XCTAssert(linkedList.count == 0 , "Linked list count should have been 0, but was \(linkedList.count) instead")
+    }
 
+    func testRemoveFirstIndex() {
+        
+        let linkedList = self.buildLinkedList()
+        let index = 0
+        
+        linkedList.removeLinkAtIndex(index)
+        let value = linkedList.linkAtIndex(index).key
+        let expectedValue = 2
+        
+        XCTAssert(value == expectedValue, "Linked list value should have been \(expectedValue), but was \(value) instead")
+        XCTAssert(linkedList.count == 5, "Linked list count should have been 5, but was \(linkedList.count) instead")
+    }
+    
+    func testRemoveAtIndex() {
+        
+        let linkedList = self.buildLinkedList()
+        let index = 2
+        
+        linkedList.removeLinkAtIndex(index)
+        let value = linkedList.linkAtIndex(index).key
+        let expectedValue = 9
+        
+        XCTAssert(value == expectedValue, "Linked list value should have been \(expectedValue), but was \(value) instead")
+        XCTAssert(linkedList.count == 5, "Linked list count should have been 5, but was \(linkedList.count) instead")
+    }
+
+    func testRemoveLastIndex() {
+        
+        let linkedList = self.buildLinkedList()
+        var index = 5
+        
+        linkedList.removeLinkAtIndex(index)
+        index -= 1
+        let value = linkedList.linkAtIndex(index).key
+        let expectedValue = 7
+        
+        XCTAssert(value == expectedValue, "Linked list value should have been \(expectedValue), but was \(value) instead")
+        XCTAssert(linkedList.count == 5, "Linked list count should have been 5, but was \(linkedList.count) instead")
+    }
     
 
     //MARK: helper functions


### PR DESCRIPTION
…nt of 1

This crash can be reproduced by creating a new LinkedList, adding a value, and then immediately removing it. The crash occurs because `head.next` is nil.

Additionally, I moved the `index == 0` check before the initialization of `current`, as it doesn't need to use it.

I can change the ternary operator to an if-statement if you think it's more readable.
