### PR TITLE
Fixed bugs in LinkedList

### DIFF
--- a/Source/Factories/LinkedList.swift
+++ b/Source/Factories/LinkedList.swift
@@ -134,6 +134,7 @@ class LinkedList<T: Equatable> {
         //check for nil conditions
         if ((index < 0) || (index > (self.count - 1))) {
             print("link index does not exist..")
+            return
         }
         
         
@@ -223,6 +224,7 @@ class LinkedList<T: Equatable> {
         if (index == 0) {
             current = current?.next
             head = current!
+            counter -= 1
             return
         }
         

--- a/SwiftStructures.xcodeproj/project.pbxproj
+++ b/SwiftStructures.xcodeproj/project.pbxproj
@@ -671,6 +671,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -689,6 +690,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/SwiftTests/LinkedTest.swift
+++ b/SwiftTests/LinkedTest.swift
@@ -103,6 +103,24 @@ class LinkedTest: XCTestCase {
             XCTFail("test failed: removed linked list element not found")
         }
         
+        // test insertion to non valid index
+        let counter = list.count
+        
+        list.insert(25, at: -1)
+        list.printAllKeys()
+        
+        if counter != list.count {
+            XCTFail("test failed: Counter mismatch after instertion")
+        }
+        
+        // test removing node at index 0
+        list.remove(at: 0)
+        list.printAllKeys()
+        
+        if list.count != counter - 1 {
+            XCTFail("test failed: Counter mismatch after removing node at index 0")
+        }
+        
         
     } //end function
     


### PR DESCRIPTION
Hello.
I've found some issues in LinkedList implementation.

I've added this in LinkedList.swift: 
func remove(): counter -= 1 added for deleting first element
func insert(): return added for inserting to non valid index

Also I've added two new tests LinkedTest.swift, func testAddLinkAtIndex()