### PR TITLE
Fixed QuickSort algorithm. Added tests for QuickSort

### DIFF
--- a/Source/Extensions/Array.swift
+++ b/Source/Extensions/Array.swift
@@ -263,53 +263,51 @@ extension Array where Element: Comparable {
     
     mutating func quickSort() -> Array<Element> {
         
-        
-        func qSort(start startIndex: Int, _ pivot: Int) {
+        func sort(lo: Int, hi: Int) {
+            guard hi > lo else { return }
             
-            if (startIndex < pivot) {
-                let iPivot = qPartition(start: startIndex, pivot)
-                qSort(start: startIndex, iPivot - 1)
-                qSort(start: iPivot + 1, pivot)
-            }
+            let j = qPartition(lo: lo, hi: hi)
+            
+            sort(lo: lo, hi: j - 1)
+            sort(lo: j + 1, hi: hi)
         }
         
-        
-        qSort(start: 0, self.endIndex - 1)
+        sort(lo: 0, hi: self.endIndex - 1)
         return self
-        
     }
     
-    
-    
-    //sorts collection-range based on pivot
-    mutating func qPartition(start startIndex: Int, _ pivot: Int) -> Int {
+    mutating func qPartition(lo: Int, hi: Int) -> Int {
+        var i = lo
+        var j = hi + 1
         
-        var wallIndex: Int = startIndex
-        
-        
-        //compare range with pivot
-        for currentIndex in wallIndex..<pivot {
+        mainLoop: while true {
             
-            print("current is: \(self[currentIndex]). pivot is \(self[pivot])")
-            
-            if self[currentIndex] <= self[pivot] {
-                if wallIndex != currentIndex {
-                    self.swapAt(currentIndex, wallIndex)
+            // rewind i
+            insideLoop: repeat {
+                i += 1
+                if i == hi {
+                    break insideLoop
                 }
-                
-                //advance wall
-                wallIndex += 1
+            } while self[i] < self[lo]
+            
+            // rewind j
+            insideLoop: repeat {
+                j -= 1
+                if j == lo {
+                    break insideLoop
+                }
+            } while self[lo] < self[j]
+            
+            if i >= j {
+                break mainLoop
             }
+            
+            self.swapAt(i, j)
         }
         
+        self.swapAt(lo, j)
         
-        //move pivot to final position
-        if wallIndex != pivot {
-            self.swapAt(wallIndex, pivot)
-        }
-        
-        return wallIndex
-        
+        return j
     }
 
     

--- a/SwiftTests/SortingTest.swift
+++ b/SwiftTests/SortingTest.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+import GameKit
 
 @testable import SwiftStructures
 
@@ -17,9 +18,20 @@ import XCTest
  the isSorted function originates from the protocol extension.
 */
 
+// size of [Int] array to test sorting algorithms
+public enum ArraySize: Int {
+    case k1 = 1000
+    case k2 = 2000
+    case k10 = 10_000
+    case k20 = 20_000
+    case k100 = 100_000
+    case k200 = 200_000
+    case m1 = 1_000_000
+}
 
 class SortingTest: XCTestCase, Sortable {
     
+    let duplicatesRatio = 0.9
     
     //test input types for algorithms
     var numberList = [8, 2, 10, 9, 7, 5]
@@ -123,6 +135,100 @@ class SortingTest: XCTestCase, Sortable {
         XCTAssert(isSorted(dateList.selectionSort()))
         
     }
+    
+    func testQuickSortDifferentTypesArrays() {
+        
+        XCTAssertTrue(isSorted(numberList.quickSort()))
+        XCTAssertTrue(isSorted(trivialNumberList.quickSort()))
+        XCTAssertTrue(isSorted(emptyNumberList.quickSort()))
+        XCTAssertTrue(isSorted(textList.quickSort()))
+        XCTAssertTrue(isSorted(triviaTextList.quickSort()))
+        XCTAssertTrue(isSorted(emptyTextList.quickSort()))
+        
+    }
+    
+    func testQuickSort() {
+        
+        let arrayToSort = Array(1...ArraySize.k10.rawValue)
+        
+        var shuffledArray = GKRandomSource.sharedRandom().arrayByShufflingObjects(in: arrayToSort) as! [Int]
+        
+        let start = Date()
+        
+        print("Start to sort")
+        let sortedArr = shuffledArray.quickSort()
+        
+        let timePassed = Date().timeIntervalSince(start)
+        
+        print("timePassed = \(timePassed)")
+        
+        XCTAssertTrue(isSorted(sortedArr))
+        
+        // O(n log n)
+        // 1000     - 0.008
+        // 10_000    - 0.083
+        // 100_000   - 0.956
+        // 1_000_000  - 11.570
+        
+    }
+    
+    func testQuickSortWithDuplicates() {
+        
+        let arraySize = ArraySize.k1.rawValue
+        
+        let arrWithDuplicates = Array<Int>(repeating: 100, count: Int(Double(arraySize) * duplicatesRatio))
+        
+        var arrNonDuplicates = [Int]()
+        if duplicatesRatio != 1.0 {
+            arrNonDuplicates = Array(101...100 + arraySize - arrWithDuplicates.count)
+        }
+        
+        let arr = arrWithDuplicates + arrNonDuplicates
+        
+        var shuffledArray = GKRandomSource.sharedRandom().arrayByShufflingObjects(in: arr) as! [Int]
+        
+        let start = Date()
+        
+        print("Start to sort")
+        
+        let sortedArr = shuffledArray.quickSort()
+        
+        let timePassed = Date().timeIntervalSince(start)
+        
+        print("timePassed = \(timePassed)")
+        
+        XCTAssertTrue(isSorted(sortedArr))
+        
+        // O(n log n)
+        // 1000     - 0.089
+        // 2000     - 0.425
+        // 10_000    - 8.796
+        
+    }
+    
+    func testQuickSortAlreadySortedArray() {
+        var arr = Array(1...ArraySize.k1.rawValue)
+        
+        let start = Date()
+        
+        print("Start to sort")
+        
+        let sortedArr = arr.quickSort()
+        
+        let timePassed = Date().timeIntervalSince(start)
+        
+        print("timePassed = \(timePassed)")
+        
+        XCTAssertTrue(isSorted(sortedArr))
+        
+        // O(n²)
+        // 1000     - 0.131
+        // 2000     - 0.398
+        // 10_000    - 8.918
+        
+    }
+    
+    
     
     
 }


### PR DESCRIPTION
I've fixed implementation of QuickSort. New implementation ensures O(n log n) complexity for case when array contains duplicates.
Old realisation provided quadratic time for such cases.
I've added tests to check QuickSort with different cases - with duplicates, with different array sized, already sorted array.